### PR TITLE
resolves issue #29

### DIFF
--- a/src/components/PopUp.jsx
+++ b/src/components/PopUp.jsx
@@ -22,6 +22,7 @@ export default function PopUp () {
       const updatedTasks = [...prevTasks, {"title": currentTask, "status": status.value}];
       setPrevTasks(updatedTasks);
       localStorage.setItem('tasks', JSON.stringify(updatedTasks));
+      window.location.reload(false);
     }
   }
 

--- a/src/components/atomic/Button.jsx
+++ b/src/components/atomic/Button.jsx
@@ -1,10 +1,12 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 export default function Button({margin, title, isColorFlipped, clickHandler}) {
 
+  const [hover, setHover] = useState(false);
+
   const button = {
     backgroundColor: isColorFlipped ? '#fff' : '#611707',
-    color: isColorFlipped? '#611707' : '#fff',
+    color: isColorFlipped ? '#611707' : '#fff',
     padding: '6px 12px',
     border: ' 1px solid #611707',
     borderRadius: '5px',
@@ -13,11 +15,14 @@ export default function Button({margin, title, isColorFlipped, clickHandler}) {
     fontFamilly: 'Poppins',
     letterSpacing: '1px',
     margin: `${margin}`,
+    transform : hover && "translateY(-3px)",
+    boxShadow : hover && "0px 2px 2px 2px rgb(97, 23, 7)",
   } 
+
 
   return (
     <div>
-        <button onClick={clickHandler} style={button}>{title}</button>
+        <button onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)} onClick={clickHandler} style={button}>{title}</button>
     </div>
   )
 }


### PR DESCRIPTION
added hover and click effects to popup buttons

## Description
added hover effect to popup buttons, and now the user can know if the add task button is clicked.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
resolves issue #29 

# Checklist:

- [+] My code follows the style guidelines of this project
- [+] I have performed a self-review of my code
- [+] I have commented my code, particularly in hard-to-understand areas
- [+] I have made corresponding changes to the documentation
- [+] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):