### PR TITLE
fix: popUp responsive using media query

### DIFF
--- a/src/components/PopUp.jsx
+++ b/src/components/PopUp.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import SelectButton from "./atomic/SelectButton";
 import Input from "./atomic/Input";
 import Button from "./atomic/Button";
@@ -10,6 +10,15 @@ export default function PopUp() {
   );
   const [status, setStatus] = useState("");
   const [currentTask, setCurrentTask] = useState("");
+
+  const [matches, setMatches] = useState(
+    window.matchMedia("(min-width: 768px)").matches
+  )
+  useEffect(() => {
+    window
+    .matchMedia("(min-width: 768px)")
+    .addEventListener('change', e => setMatches( e.matches ));
+  }, []);
 
   const handleInputChange = (e) => {
     setCurrentTask(e.target.value);
@@ -43,7 +52,7 @@ export default function PopUp() {
   };
 
   const popUpSizer = {
-    width: "25%",
+    width: `${matches ? '40%' : '90%'}`,
   };
 
   const popUpStyles = {


### PR DESCRIPTION
Closes #39 

### What does this PR solve?
The width was too small for smaller screen. Hard-coding the value to a certain percentage was not enough

### Solution 
dynamic width according to screen size

The pupUp component is now using a media query which will adjust the width of popUp 
This was needed because the hard-coded width (`width : 40%`) was too small for smaller screen and too large bigger screen



## Related Issue 
#39 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->



## How Has This Been Tested?

_No tests_
This do not affect the application in any way so No tests are required

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review 

https://user-images.githubusercontent.com/103348863/193466100-87588434-163e-40af-b340-4d95a6599968.mp4

of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
