### PR TITLE
Bring pop up on top of everything

### DIFF
--- a/src/components/PopUp.jsx
+++ b/src/components/PopUp.jsx
@@ -36,7 +36,7 @@ export default function PopUp(props) {
     <div
       className={`${
         props.visible ? `scale-100` : `scale-0`
-      } flex absolute inset-0 w-full h-full bg-black/50 flex-col justify-center items-center`}
+      } flex absolute inset-0 w-full h-full bg-black/50 flex-col justify-center items-center z-[9999]`}
     >
       <div className={"w-4/5 max-w-sm"}>
         <div className="w-[10%] bg-coffeePrimaryLight mb-2 flex justify-center ml-auto cursor-pointer">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Provided a Z Index to the popup to bring it on top of everything

<!--- Describe your changes in detail -->
Previously, the the Add button used to come in front of the pop up on mobile device. I haven given the pop up container a z index to bring it on top of everything

Fixes issue #66 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/51002433/194374727-39169995-12cd-4dae-b0ee-07e60824e6a2.png)
